### PR TITLE
build: Fix main class name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
                             <goal>repackage</goal>
                         </goals>
                         <configuration>
-                            <mainClass>org.pkarakal.networking.NetworkingW</mainClass>
+                            <mainClass>org.pkarakal.networking.Networking</mainClass>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
Fix build after a typo I made in #7 in the main class name